### PR TITLE
Export Stream class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import {Client} from './client';
 import {Config} from './mux';
 import {Server} from './server';
+import {Stream} from './stream';
 
-export {Config, Client, Server};
+export {Config, Client, Server, Stream};

--- a/src/session.ts
+++ b/src/session.ts
@@ -211,8 +211,8 @@ export class Session extends Transform {
         return this.send(hdr);
     }
 
-    // Open is used to create a new stream as a Duplex
-    public open(): Duplex {
+    // Open is used to create a new stream
+    public open(): Stream {
         const stream = new Stream(this, this.nextStreamID, STREAM_STATES.Init);
         this.nextStreamID += 2;
 


### PR DESCRIPTION
Currently it's impossible to use `Stream` class public methods (like `close`).