### PR TITLE
[stream] add window size tracking

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -5,7 +5,6 @@ import {Header} from './header';
 import {Session} from './session';
 
 export class Stream extends Duplex {
-    private HEADER_SIZE = 12;
     private recvWindow: number;
     private sendWindow: number;
     private id: number;
@@ -61,8 +60,8 @@ export class Stream extends Duplex {
                 const buffers = [sendHdr.encode(), chunk];
                 const packet = Buffer.concat(buffers);
 
-                const rest = packet.slice(packetLength + this.HEADER_SIZE);
-                const packetToSend = packet.slice(0, packetLength + this.HEADER_SIZE);
+                const rest = packet.slice(packetLength + Header.LENGTH);
+                const packetToSend = packet.slice(0, packetLength + Header.LENGTH);
                 this.sendWindow -= packetLength;
 
                 const writeTimeout = setTimeout(() => {


### PR DESCRIPTION
The send window is currently not tracked leading to window exceeded errors when used with the Golang implementation as a server.
This PR adds this tracking of the send window to avoid sending too much data to the server until it sends a window update packet. (according to the golang implementation: https://github.com/hashicorp/yamux/blob/master/stream.go#L202-L203)
