### PR TITLE
Update `Session` and `Stream` to emit `Error`s on 'error' events

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -38,51 +38,51 @@ export enum GO_AWAY_ERRORS {
     goAwayInternalErr = 2,
 }
 
-export enum ERRORS {
+export const ERRORS = {
     // ErrInvalidVersion means we received a frame with an
     // invalid version
-    errInvalidVersion = 'invalid protocol version',
+    errInvalidVersion: new Error('invalid protocol version'),
 
     // ErrInvalidMsgType means we received a frame with an
     // invalid message type
-    errInvalidMsgType = 'invalid msg type',
+    errInvalidMsgType: new Error('invalid msg type'),
 
     // ErrSessionShutdown is used if there is a shutdown during
     // an operation
-    errSessionShutdown = 'session shutdown',
+    errSessionShutdown: new Error('session shutdown'),
 
     // ErrStreamsExhausted is returned if we have no more
     // stream ids to issue
     // WARNING [Difference with the Go implementation]: not used in the Node.js lib
-    errStreamsExhausted = 'streams exhausted',
+    errStreamsExhausted: new Error('streams exhausted'),
 
     // ErrDuplicateStream is used if a duplicate stream is
     // opened inbound
-    errDuplicateStream = 'duplicate stream initiated',
+    errDuplicateStream: new Error('duplicate stream initiated'),
 
     // ErrReceiveWindowExceeded indicates the window was exceeded
-    errRecvWindowExceeded = 'recv window exceeded',
+    errRecvWindowExceeded: new Error('recv window exceeded'),
 
     // ErrTimeout is used when we reach an IO deadline
-    errTimeout = 'i/o deadline reached',
+    errTimeout: new Error('i/o deadline reached'),
 
     // ErrStreamClosed is returned when using a closed stream
-    errStreamClosed = 'stream closed',
+    errStreamClosed: new Error('stream closed'),
 
     // ErrUnexpectedFlag is set when we get an unexpected flag
-    errUnexpectedFlag = 'unexpected flag',
+    errUnexpectedFlag: new Error('unexpected flag'),
 
     // ErrRemoteGoAway is used when we get a go away from the other side
-    errRemoteGoAway = 'remote end is not accepting connections',
+    errRemoteGoAway: new Error('remote end is not accepting connections'),
 
     // ErrConnectionReset is sent if a stream is reset. This can happen
     // if the backlog is exceeded, or if there was a remote GoAway.
-    errConnectionReset = 'connection reset',
+    errConnectionReset: new Error('connection reset'),
 
     // ErrConnectionWriteTimeout indicates that we hit the "safety valve"
     // timeout writing to the underlying stream connection.
-    errConnectionWriteTimeout = 'connection write timeout',
+    errConnectionWriteTimeout: new Error('connection write timeout'),
 
     // ErrKeepAliveTimeout is sent if a missed keepalive caused the stream close
-    errKeepAliveTimeout = 'keepalive timeout',
-}
+    errKeepAliveTimeout: new Error('keepalive timeout'),
+} as const;

--- a/src/session.ts
+++ b/src/session.ts
@@ -169,7 +169,7 @@ export class Session extends Transform {
         });
 
         if (error) {
-            this.emit('error', error);
+            this.emit('error', new Error(error));
         }
         this.end();
     }
@@ -188,7 +188,7 @@ export class Session extends Transform {
         // Check if stream already exists
         if (this.streams.has(streamID)) {
             this.config.logger('[ERR] yamux: duplicate stream declared');
-            this.emit('error', ERRORS.errDuplicateStream);
+            this.emit('error', new Error(ERRORS.errDuplicateStream));
             return this.goAway(GO_AWAY_ERRORS.goAwayProtoErr);
         }
 
@@ -220,11 +220,11 @@ export class Session extends Transform {
         this.nextStreamID += 2;
 
         if (this.isClosed()) {
-            this.emit('error', ERRORS.errSessionShutdown);
+            this.emit('error', new Error(ERRORS.errSessionShutdown));
             return stream;
         }
         if (this.remoteGoAway) {
-            this.emit('error', ERRORS.errRemoteGoAway);
+            this.emit('error', new Error(ERRORS.errRemoteGoAway));
             return stream;
         }
 
@@ -252,7 +252,7 @@ export class Session extends Transform {
     // Ping is used to measure the RTT response time
     private ping() {
         if (this.shutdown) {
-            this.emit('error', ERRORS.errSessionShutdown);
+            this.emit('error', new Error(ERRORS.errSessionShutdown));
             return;
         }
         const pingID = this.pingID++;
@@ -261,7 +261,7 @@ export class Session extends Transform {
         // Wait for a response
         const responseTimeout = setTimeout(() => {
             clearTimeout(responseTimeout); // Ignore it if a response comes later.
-            this.emit('error', ERRORS.errKeepAliveTimeout);
+            this.emit('error', new Error(ERRORS.errKeepAliveTimeout));
             this.close(ERRORS.errTimeout);
         }, this.config.connectionWriteTimeout * 1000);
         this.pings.set(pingID, responseTimeout);

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -35,7 +35,7 @@ export class Stream extends Duplex {
                 this.recvWindow,
                 size
             );
-            this.emit('error', ERRORS.errRecvWindowExceeded);
+            this.emit('error', new Error(ERRORS.errRecvWindowExceeded));
         }
     }
 
@@ -44,10 +44,10 @@ export class Stream extends Duplex {
             case STREAM_STATES.LocalClose:
             case STREAM_STATES.RemoteClose:
             case STREAM_STATES.Closed:
-                this.emit('error', ERRORS.errStreamClosed);
+                this.emit('error', new Error(ERRORS.errStreamClosed));
                 break;
             case STREAM_STATES.Reset:
-                this.emit('error', ERRORS.errConnectionReset);
+                this.emit('error', new Error(ERRORS.errConnectionReset));
                 break;
             default:
                 if (this.sendWindow === 0) {
@@ -65,7 +65,7 @@ export class Stream extends Duplex {
                 this.sendWindow -= packetLength;
 
                 const writeTimeout = setTimeout(() => {
-                    this.emit('error', ERRORS.errConnectionWriteTimeout);
+                    this.emit('error', new Error(ERRORS.errConnectionWriteTimeout));
                     clearTimeout(writeTimeout);
                 }, this.session.config.connectionWriteTimeout * 1000);
                 this.session.push(packetToSend, encoding);
@@ -166,7 +166,7 @@ export class Stream extends Duplex {
                     break;
                 default:
                     this.session.config.logger('[ERR] yamux: unexpected FIN flag in state %d', this.state);
-                    this.emit('error', ERRORS.errUnexpectedFlag);
+                    this.emit('error', new Error(ERRORS.errUnexpectedFlag));
                     return;
             }
         }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -35,7 +35,7 @@ export class Stream extends Duplex {
                 this.recvWindow,
                 size
             );
-            this.emit('error', new Error(ERRORS.errRecvWindowExceeded));
+            this.emit('error', ERRORS.errRecvWindowExceeded);
         }
     }
 
@@ -44,10 +44,10 @@ export class Stream extends Duplex {
             case STREAM_STATES.LocalClose:
             case STREAM_STATES.RemoteClose:
             case STREAM_STATES.Closed:
-                this.emit('error', new Error(ERRORS.errStreamClosed));
+                this.emit('error', ERRORS.errStreamClosed);
                 break;
             case STREAM_STATES.Reset:
-                this.emit('error', new Error(ERRORS.errConnectionReset));
+                this.emit('error', ERRORS.errConnectionReset);
                 break;
             default:
                 if (this.sendWindow === 0) {
@@ -65,7 +65,7 @@ export class Stream extends Duplex {
                 this.sendWindow -= packetLength;
 
                 const writeTimeout = setTimeout(() => {
-                    this.emit('error', new Error(ERRORS.errConnectionWriteTimeout));
+                    this.emit('error', ERRORS.errConnectionWriteTimeout);
                     clearTimeout(writeTimeout);
                 }, this.session.config.connectionWriteTimeout * 1000);
                 this.session.push(packetToSend, encoding);
@@ -166,7 +166,7 @@ export class Stream extends Duplex {
                     break;
                 default:
                     this.session.config.logger('[ERR] yamux: unexpected FIN flag in state %d', this.state);
-                    this.emit('error', new Error(ERRORS.errUnexpectedFlag));
+                    this.emit('error', ERRORS.errUnexpectedFlag);
                     return;
             }
         }

--- a/test/constants.test.ts
+++ b/test/constants.test.ts
@@ -56,19 +56,19 @@ describe('Constants', () => {
 
     describe('Errors', () => {
         it('should have the correct values', () => {
-            expect(ERRORS.errInvalidVersion).to.equal('invalid protocol version');
-            expect(ERRORS.errInvalidMsgType).to.equal('invalid msg type');
-            expect(ERRORS.errSessionShutdown).to.equal('session shutdown');
-            expect(ERRORS.errStreamsExhausted).to.equal('streams exhausted');
-            expect(ERRORS.errDuplicateStream).to.equal('duplicate stream initiated');
-            expect(ERRORS.errRecvWindowExceeded).to.equal('recv window exceeded');
-            expect(ERRORS.errTimeout).to.equal('i/o deadline reached');
-            expect(ERRORS.errStreamClosed).to.equal('stream closed');
-            expect(ERRORS.errUnexpectedFlag).to.equal('unexpected flag');
-            expect(ERRORS.errRemoteGoAway).to.equal('remote end is not accepting connections');
-            expect(ERRORS.errConnectionReset).to.equal('connection reset');
-            expect(ERRORS.errConnectionWriteTimeout).to.equal('connection write timeout');
-            expect(ERRORS.errKeepAliveTimeout).to.equal('keepalive timeout');
+            expect(ERRORS.errInvalidVersion.message).to.equal('invalid protocol version');
+            expect(ERRORS.errInvalidMsgType.message).to.equal('invalid msg type');
+            expect(ERRORS.errSessionShutdown.message).to.equal('session shutdown');
+            expect(ERRORS.errStreamsExhausted.message).to.equal('streams exhausted');
+            expect(ERRORS.errDuplicateStream.message).to.equal('duplicate stream initiated');
+            expect(ERRORS.errRecvWindowExceeded.message).to.equal('recv window exceeded');
+            expect(ERRORS.errTimeout.message).to.equal('i/o deadline reached');
+            expect(ERRORS.errStreamClosed.message).to.equal('stream closed');
+            expect(ERRORS.errUnexpectedFlag.message).to.equal('unexpected flag');
+            expect(ERRORS.errRemoteGoAway.message).to.equal('remote end is not accepting connections');
+            expect(ERRORS.errConnectionReset.message).to.equal('connection reset');
+            expect(ERRORS.errConnectionWriteTimeout.message).to.equal('connection write timeout');
+            expect(ERRORS.errKeepAliveTimeout.message).to.equal('keepalive timeout');
         });
     });
 });

--- a/test/session.test.ts
+++ b/test/session.test.ts
@@ -56,7 +56,7 @@ describe('Server session', () => {
     it('errors if pings time out', (done) => {
         const server = new Session(false, testConfigWithKeepAlive);
         server.on('error', (err) => {
-            expect(err).to.equal('keepalive timeout');
+            expect(err.toString()).to.equal('Error: keepalive timeout');
             server.removeAllListeners('error');
             server.close();
             return done();
@@ -133,7 +133,7 @@ describe('Server session', () => {
     it('handles Go away', (done) => {
         const {server, client} = getServerAndClient(testConfig, testConfig);
         client.on('error', (err) => {
-            expect(err).to.equal('remote end is not accepting connections');
+            expect(err.toString()).to.equal('Error: remote end is not accepting connections');
             done();
         });
         server.close();


### PR DESCRIPTION
Emit `Error` objects instead of string on `error` events to fit [node convention](https://nodejs.org/api/events.html#events_error_events).