### PR TITLE
[stream] add support for receive window update

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -138,6 +138,7 @@ export class Session extends Transform {
         }
 
         stream.push(fullPacket, encoding);
+        stream.updateRecvWindow(fullPacket.length);
     }
 
     public closeStream(streamID: number) {

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -115,6 +115,12 @@ export class Stream extends Duplex {
         this.session.send(this.controlHdr);
     }
 
+    public updateRecvWindow(receivedSize: number) {
+        this.recvWindow -= receivedSize;
+
+        this.sendWindowUpdate();
+    }
+
     // sendClose is used to send a FIN
     private sendClose() {
         const flags = FLAGS.FIN;


### PR DESCRIPTION
This PR adds support for receive window tracking in yamux-js.

It is required to be able to send window updates at the right moment, else the remote party may stop sending data as it may suppose out receiving buffer is full.