### PR TITLE
Fix issue when there is data right after a window update

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -92,6 +92,9 @@ export class Session extends Transform {
             case TYPES.WindowUpdate:
                 this.handleStreamMessage(this.currentHeader, packet, encoding);
                 this.currentHeader = undefined;
+                if (packet.length > 0) {
+                    return this._transform(packet, encoding, cb);
+                }
                 break;
             case TYPES.Ping:
                 this.handlePing(this.currentHeader);
@@ -135,6 +138,7 @@ export class Session extends Transform {
         // Check if this is a window update
         if (currentHeader.type === TYPES.WindowUpdate) {
             stream.incrSendWindow(currentHeader);
+            return;
         }
 
         stream.push(fullPacket, encoding);


### PR DESCRIPTION
This PR aims at fixing a bug where the buffer contains data right after a "window update" header (for which there is no data, the header is self-contained), which was discarded previously - a bug that is visible with some multiplexing examples like in https://github.com/th-ch/yamux-js/issues/13.

Implementation aims at matching the [Go implementation](https://github.com/hashicorp/yamux/blob/master/session.go#L616), which returns early for window updates.