### PR TITLE
fix: handle FIN flag correctly in processFlags()

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -161,12 +161,13 @@ export class Stream extends Duplex {
                 this.state = STREAM_STATES.Established;
             }
         }
-        if (flags === FLAGS.SYN) {
+        if (flags === FLAGS.FIN) {
             switch (this.state) {
                 case STREAM_STATES.SYNSent:
                 case STREAM_STATES.SYNReceived:
                 case STREAM_STATES.Established:
                     this.state = STREAM_STATES.RemoteClose;
+                    this.push(null);
                     break;
                 case STREAM_STATES.LocalClose:
                     this.state = STREAM_STATES.Closed;

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 
-import {STREAM_STATES, TYPES, VERSION} from '../src/constants';
+import {FLAGS, STREAM_STATES, TYPES, VERSION} from '../src/constants';
 import {Header} from '../src/header';
 import {Session} from '../src/session';
 import {Stream} from '../src/stream';
@@ -128,5 +128,19 @@ describe('Stream', () => {
             done();
         });
         stream.close();
+    });
+
+    it('transitions to remote close and ends the readable side on FIN', (done) => {
+        const {stream, session} = createStream(0, STREAM_STATES.Established);
+        const hdr = new Header(VERSION, TYPES.WindowUpdate, FLAGS.FIN, stream.ID(), 0);
+
+        stream.on('end', () => {
+            expect(stream['state']).to.equal(STREAM_STATES.RemoteClose);
+            session.close();
+            done();
+        });
+
+        stream.resume();
+        stream.incrSendWindow(hdr);
     });
 });


### PR DESCRIPTION
### What
- processFlags() was checking FLAGS.SYN (0x1) where it should check FLAGS.FIN (0x4).
- This caused stream close frames (FIN) to be silently ignored by the receiving side. 
- When a peer called stream.close() to signal half-close, the receiver never transitioned to RemoteClose state, leaving the stream as a zombie — alive locally but dead on the remote end.

### Changes:
FLAGS.SYN → FLAGS.FIN in processFlags() (the actual bug)
Added this.push(null) on RemoteClose to signal EOF to Node.js readable stream machinery, enabling pipe() to propagate the close